### PR TITLE
Remove the this reference which was causing a crash for limit orders

### DIFF
--- a/lisk-dex-electron/src/PlaceOrder.js
+++ b/lisk-dex-electron/src/PlaceOrder.js
@@ -91,13 +91,13 @@ export default class PlaceOrder extends React.Component {
       let destChain = undefined;
       let broadcastURL = undefined;
       if (this.props.side === 'buy') {
-        dexAddress = this.dex_addresses[this.context.currentMarket[1]]
+        dexAddress = dex_addresses[this.context.currentMarket[1]]
         destAddress = this.context.keys[this.context.currentMarket[0]].address;
         passphrase = this.context.keys[this.context.currentMarket[1]].passphrase;
         destChain = this.context.currentMarket[0];
         broadcastURL = blockchainAPIURLS[this.context.currentMarket[1]];
       } else if (this.props.side === 'sell') {
-        dexAddress = this.dex_addresses[this.context.currentMarket[0]]
+        dexAddress = dex_addresses[this.context.currentMarket[0]]
         destAddress = this.context.keys[this.context.currentMarket[1]].address;
         passphrase = this.context.keys[this.context.currentMarket[0]].passphrase;
         destChain = this.context.currentMarket[1];


### PR DESCRIPTION
Removing the `this` reference fixed the issue.
Feel free to close if this fix is not how it was intended.